### PR TITLE
Solving dependency with module future

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 #from distutils.core import setup #changed to distutils.core for pypy comptibility
 from setuptools import setup
-from pyevolve import __version__, __author__
 import sys
 
 setup(
    name = "Pyevolve",
-   version = __version__,
+   version = '0.6',
    packages = ["pyevolve"],
    scripts = ['pyevolve_graph.py'],
    install_requires = ['future'],
@@ -13,7 +12,7 @@ setup(
       'pyevolve': ['*.txt']
    },
    test_suite = 'tests',
-   author = __author__,
+   author = 'Christian S. Perone',
    author_email = "christian.perone@gmail.com",
    description = "A complete, free and open-source evolutionary framework written in Python",
    license = "PSF",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
    version = __version__,
    packages = ["pyevolve"],
    scripts = ['pyevolve_graph.py'],
+   install_requires = ['future'],
    package_data = {
       'pyevolve': ['*.txt']
    },


### PR DESCRIPTION
Hello
I've noticed that the module 'future' has to be pre-installed in order to install the package using pip.
I've added future as an install dependency in setup.py. That needed to hard-code the version and author information in setup.py

Thanks!
Have a nice day
Héctor
